### PR TITLE
EDGERM-3: edge-common-spring 2.4.4, Spring Boot 3.2.6 fixing vulns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.2.4</version>
+    <version>3.2.6</version>
     <relativePath />
   </parent>
 
@@ -26,7 +26,7 @@
 
   <properties>
     <java.version>17</java.version>
-    <edge-common-spring-version>2.4.1</edge-common-spring-version>
+    <edge-common-spring-version>2.4.4</edge-common-spring-version>
     <folio-spring-cql-version>8.1.0</folio-spring-cql-version>
     <openapi-generator.version>7.4.0</openapi-generator.version>
     <spring-cloud-wiremock>4.1.1</spring-cloud-wiremock>


### PR DESCRIPTION
Upgrade edge-common-spring from 2.4.1 to 2.4.4.

Upgrade Spring Boot from 3.2.4 to 3.2.6.

These upgrades fix security vulnerabilities.

The edge-common-spring upgrade indirectly upgrades bcprov-jdk18on from 1.74 to 1.78 fixing multiple vulnerabilities:

* https://www.cve.org/CVERecord?id=CVE-2024-30172  Ed25519 Infinitive Loop
* https://www.cve.org/CVERecord?id=CVE-2024-30171  RSA side-channel attack
* https://security.snyk.io/vuln/SNYK-JAVA-ORGBOUNCYCASTLE-6277381  PKCS#1 1.5 and OAEP side-channel attack
* https://www.cve.org/CVERecord?id=CVE-2024-29857  ECCurve excessive CPU consumption

The bcprov-jdk18on vulnerabilities affect TLS:

* Both Ed25519 and RSA/*-RSA are used in TLSv1.2 and TLSv1.3: https://en.wikipedia.org/wiki/Transport_Layer_Security#Key_exchange_or_key_agreement
* ECCurve is a commonly used public key algorithm for certificates in TLSv1.2 and TLSv1.3. http://Letsencrypt.org  certbot uses it by default since version 2.0.0.

As edge-erm may use TLS when connecting to secure store or to Okapi the fix is needed.

The edge-common-spring upgrade and the Spring Boot upgrade indirectly upgrade spring-web from 6.1.5 to 6.1.8 fixing UriComponentsBuilder Open Redirect:

https://spring.io/security/cve-2024-22259
https://spring.io/security/cve-2024-22262

The edge-common-spring upgrade indirectly upgrades netty-codec-http from 4.1.107.Final to 4.1.110.Final fixing form POST OOM:

https://github.com/netty/netty/security/advisories/GHSA-5jpm-x58v-624v = CVE-2024-29025