### PR TITLE
EDGERM-4: Upgrade edge-common-spring version and add TLS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,115 @@ tenants=mytenant
 mytenant=edgeuser,password
 ```
 
+### TLS Configuration for HTTP Endpoints
+
+To configure Transport Layer Security (TLS) for HTTP endpoints in edge module, the following configuration parameters can be used. These parameters allow you to specify key and keystore details necessary for setting up TLS.
+
+#### Configuration Parameters
+
+1. **`spring.ssl.bundle.jks.web-server.key.password`**
+- **Description**: Specifies the password for the private key in the keystore.
+- **Example**: `spring.ssl.bundle.jks.web-server.key.password=SecretPassword`
+
+2. **`spring.ssl.bundle.jks.web-server.key.alias`**
+- **Description**: Specifies the alias of the key within the keystore.
+- **Example**: `spring.ssl.bundle.jks.web-server.key.alias=localhost`
+
+3. **`spring.ssl.bundle.jks.web-server.keystore.location`**
+- **Description**: Specifies the location of the keystore file in the local file system.
+- **Example**: `spring.ssl.bundle.jks.web-server.keystore.location=/some/secure/path/test.keystore.bcfks`
+
+4. **`spring.ssl.bundle.jks.web-server.keystore.password`**
+- **Description**: Specifies the password for the keystore.
+- **Example**: `spring.ssl.bundle.jks.web-server.keystore.password=SecretPassword`
+
+5. **`spring.ssl.bundle.jks.web-server.keystore.type`**
+- **Description**: Specifies the type of the keystore. Common types include `JKS`, `PKCS12`, and `BCFKS`.
+- **Example**: `spring.ssl.bundle.jks.web-server.keystore.type=BCFKS`
+
+6. **`server.ssl.bundle`**
+- **Description**: Specifies which SSL bundle to use for configuring the server. This parameter links to the defined SSL bundle, for example, `web-server`.
+- **Example**: `server.ssl.bundle=web-server`
+
+7. **`server.port`**
+- **Description**: Specifies the port on which the server will listen for HTTPS requests.
+- **Example**: `server.port=8443`
+
+#### Example Configuration
+
+To enable TLS for the edge module using the above parameters, you need to provide them as the environment variables. Below is an example configuration:
+
+```properties
+spring.ssl.bundle.jks.web-server.key.password=SecretPassword
+spring.ssl.bundle.jks.web-server.key.alias=localhost
+spring.ssl.bundle.jks.web-server.keystore.location=classpath:test/test.keystore.bcfks
+spring.ssl.bundle.jks.web-server.keystore.password=SecretPassword
+spring.ssl.bundle.jks.web-server.keystore.type=BCFKS
+
+server.ssl.bundle=web-server
+server.port=8443
+```
+Also, you can use the relaxed binding with the upper case format, which is recommended when using system environment variables.
+```properties
+SPRING_SSL_BUNDLE_JKS_WEBSERVER_KEY_PASSWORD=SecretPassword
+SPRING_SSL_BUNDLE_JKS_WEBSERVER_KEY_ALIAS=localhost
+SPRING_SSL_BUNDLE_JKS_WEBSERVER_KEYSTORE_LOCATION=classpath:test/test.keystore.bcfks
+SPRING_SSL_BUNDLE_JKS_WEBSERVER_KEYSTORE_PASSWORD=SecretPassword
+SPRING_SSL_BUNDLE_JKS_WEBSERVER_KEYSTORE_TYPE=BCFKS
+
+SERVER_SSL_BUNDLE=web-server
+SERVER_PORT=8443
+```
+
+### TLS Configuration for Feign HTTP Clients
+
+To configure Transport Layer Security (TLS) for HTTP clients created using Feign annotations in the edge module, you can use the following configuration parameters. These parameters allow you to specify trust store details necessary for setting up TLS for Feign clients.
+
+#### Configuration Parameters
+
+1. **`folio.client.okapiUrl`**
+- **Description**: Specifies the base URL for the Okapi service.
+- **Example**: `folio.client.okapiUrl=https://okapi:443`
+
+2. **`folio.client.tls.enabled`**
+- **Description**: Enables or disables TLS for the Feign clients.
+- **Example**: `folio.client.tls.enabled=true`
+
+3. **`folio.client.tls.trustStorePath`**
+- **Description**: Specifies the location of the trust store file.
+- **Example**: `folio.client.tls.trustStorePath=classpath:/some/secure/path/test.truststore.bcfks`
+
+4. **`folio.client.tls.trustStorePassword`**
+- **Description**: Specifies the password for the trust store.
+- **Example**: `folio.client.tls.trustStorePassword="SecretPassword"`
+
+5. **`folio.client.tls.trustStoreType`**
+- **Description**: Specifies the type of the trust store. Common types include `JKS`, `PKCS12`, and `BCFKS`.
+- **Example**: `folio.client.tls.trustStoreType=bcfks`
+
+#### Note
+The `trustStorePath`, `trustStorePassword`, and `trustStoreType` parameters can be omitted if the server provides a public certificate.
+
+#### Example Configuration
+
+To enable TLS for Feign HTTP clients using the above parameters, you need to provide them as the environment variables. Below is an example configuration:
+
+```properties
+folio.client.okapiUrl=https://okapi:443
+folio.client.tls.enabled=true
+folio.client.tls.trustStorePath=classpath:test/test.truststore.bcfks
+folio.client.tls.trustStorePassword=SecretPassword
+folio.client.tls.trustStoreType=bcfks
+```
+Also, you can use the relaxed binding with the upper case format, which is recommended when using system environment variables.
+```properties
+FOLIO_CLIENT_OKAPIURL=https://okapi:443
+FOLIO_CLIENT_TLS_ENABLED=true
+FOLIO_CLIENT_TLS_TRUSTSTOREPATH=classpath:test/test.truststore.bcfks
+FOLIO_CLIENT_TLS_TRUSTSTOREPASSWORD=SecretPassword
+FOLIO_CLIENT_TLS_TRUSTSTORETYPE=bcfks
+```
+
 ### Required permissions for system user
 `licenses.licenses.item.get`
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
   <properties>
     <java.version>17</java.version>
-    <edge-common-spring-version>2.4.4</edge-common-spring-version>
+    <edge-common-spring-version>2.4.5</edge-common-spring-version>
     <folio-spring-cql-version>8.1.0</folio-spring-cql-version>
     <openapi-generator.version>7.4.0</openapi-generator.version>
     <spring-cloud-wiremock>4.1.1</spring-cloud-wiremock>
@@ -182,7 +182,7 @@
       <plugin>
         <groupId>com.coderplus.maven.plugins</groupId>
         <artifactId>copy-rename-maven-plugin</artifactId>
-        <version>1.0</version>
+        <version>1.0.1</version>
         <executions>
           <execution>
             <id>rename-descriptor-outputs</id>
@@ -258,7 +258,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
-        <version>2.5.3</version>
+        <version>3.0.1</version>
         <configuration>
           <preparationGoals>clean verify</preparationGoals>
           <tagNameFormat>v@{project.version}</tagNameFormat>

--- a/src/main/java/org/folio/edge/erm/EdgeErmApplication.java
+++ b/src/main/java/org/folio/edge/erm/EdgeErmApplication.java
@@ -1,5 +1,8 @@
 package org.folio.edge.erm;
 
+import static org.folio.common.utils.tls.FipsChecker.getFipsChecksResultString;
+
+import lombok.extern.log4j.Log4j2;
 import org.folio.spring.cql.JpaCqlConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -8,9 +11,11 @@ import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication(exclude = {DataSourceAutoConfiguration.class, JpaCqlConfiguration.class})
 @EnableFeignClients
+@Log4j2
 public class EdgeErmApplication {
 
   public static void main(String[] args) {
+    log.info(getFipsChecksResultString());
     SpringApplication.run(EdgeErmApplication.class, args);
   }
 

--- a/src/main/java/org/folio/edge/erm/config/ErmClientConfig.java
+++ b/src/main/java/org/folio/edge/erm/config/ErmClientConfig.java
@@ -1,9 +1,39 @@
 package org.folio.edge.erm.config;
 
+import static org.folio.common.utils.FeignClientTlsUtils.getSslOkHttpClient;
+
 import feign.okhttp.OkHttpClient;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import okhttp3.ConnectionPool;
+import okhttp3.Protocol;
+import org.folio.edgecommonspring.client.EdgeFeignClientProperties;
+import org.springframework.cloud.openfeign.support.FeignHttpClientProperties;
 import org.springframework.context.annotation.Bean;
 
+@AllArgsConstructor
 public class ErmClientConfig {
+  private final EdgeFeignClientProperties properties;
+
+  @Bean
+  public okhttp3.OkHttpClient okHttpClient(okhttp3.OkHttpClient.Builder builder, ConnectionPool connectionPool,
+      FeignHttpClientProperties httpClientProperties) {
+    boolean followRedirects = httpClientProperties.isFollowRedirects();
+    int connectTimeout = httpClientProperties.getConnectionTimeout();
+    Duration readTimeout = httpClientProperties.getOkHttp().getReadTimeout();
+    List<Protocol> protocols = httpClientProperties.getOkHttp().getProtocols().stream().map(Protocol::valueOf)
+        .collect(Collectors.toList());
+
+    builder.connectTimeout(connectTimeout, TimeUnit.MILLISECONDS)
+        .followRedirects(followRedirects).readTimeout(readTimeout).connectionPool(connectionPool)
+        .protocols(protocols).build();
+    var tls = properties.getTls();
+    return tls != null  && Boolean.TRUE.equals(tls.isEnabled()) ?
+        getSslOkHttpClient(builder.build(), tls) : builder.build();
+  }
 
   @Bean
   public OkHttpClient feignOkHttpClient(okhttp3.OkHttpClient okHttpClient) {

--- a/src/main/java/org/folio/edge/erm/service/ErmService.java
+++ b/src/main/java/org/folio/edge/erm/service/ErmService.java
@@ -1,6 +1,9 @@
 package org.folio.edge.erm.service;
 
+import static org.apache.maven.shared.utils.StringUtils.isBlank;
+
 import org.folio.edge.erm.client.ErmClient;
+import org.folio.edgecommonspring.client.EdgeFeignClientProperties;
 import org.folio.erm.domain.dto.LicenseTerms;
 import org.folio.erm.domain.dto.LicenseTermsBatch;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -40,8 +43,13 @@ public class ErmService {
   private static final String FAILED_TO_MAP_RESPONSE = "Failed to map licenses response";
   private final ErmClient ermClient;
   private final ObjectMapper objectMapper;
+  private final EdgeFeignClientProperties properties;
 
-  @Value("${okapi_url}")
+  /**
+   * @deprecated
+   */
+  @Deprecated(since = "1.2.0", forRemoval = false)
+  @Value("${okapi_url:NO_VALUE}")
   private String okapiUrl;
 
   @SneakyThrows
@@ -77,7 +85,12 @@ public class ErmService {
   }
 
   private ObjectNode getLicenceTermByIdResponseNode(String id, String tenant, String token) {
-    var response = ermClient.getLicenseTerms(URI.create(okapiUrl), id, tenant, token);
+    var okapiUrlToUse = properties.getOkapiUrl();
+    if (isBlank(okapiUrlToUse)) {
+      log.warn("deprecated property okapi_url is used. Please use folio.client.okapiUrl instead.");
+      okapiUrlToUse = okapiUrl;
+    }
+    var response = ermClient.getLicenseTerms(URI.create(okapiUrlToUse), id, tenant, token);
     try {
       var processedLicenses = processClientResponse(response);
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,6 +21,10 @@ folio:
   tenant:
     validation:
       enabled: false
+  client:
+    okapiUrl: http://localhost:9130
+    tls:
+      enabled: false
 
 logging:
   config: classpath:log4j2.xml

--- a/src/test/java/org/folio/edge/erm/BaseIntegrationTests.java
+++ b/src/test/java/org/folio/edge/erm/BaseIntegrationTests.java
@@ -11,6 +11,7 @@ import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemp
 import java.util.List;
 import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j2;
+import org.folio.edgecommonspring.client.EdgeFeignClientProperties;
 import org.folio.edgecommonspring.client.EnrichUrlClient;
 import org.folio.spring.integration.XOkapiHeaders;
 import org.junit.jupiter.api.AfterAll;
@@ -39,10 +40,13 @@ public abstract class BaseIntegrationTests {
   private static final String TEST_API_KEY = "eyJzIjoiQlBhb2ZORm5jSzY0NzdEdWJ4RGgiLCJ0IjoidGVzdCIsInUiOiJ0ZXN0X2FkbWluIn0=";
 
   @BeforeAll
-  static void beforeAll(@Autowired EnrichUrlClient enrichUrlClient, @Autowired ErmService ermService) {
+  static void beforeAll(@Autowired EnrichUrlClient enrichUrlClient, @Autowired ErmService ermService,
+      @Autowired EdgeFeignClientProperties properties) {
     WIRE_MOCK.start();
-    ReflectionTestUtils.setField(enrichUrlClient, "okapiUrl", WIRE_MOCK.baseUrl());
-    ReflectionTestUtils.setField(ermService, "okapiUrl", WIRE_MOCK.baseUrl());
+    var url = WIRE_MOCK.baseUrl();
+    ReflectionTestUtils.setField(enrichUrlClient, "okapiUrl", url);
+    ReflectionTestUtils.setField(ermService, "okapiUrl", url);
+    ReflectionTestUtils.setField(properties, "okapiUrl", url);
   }
 
   @AfterAll


### PR DESCRIPTION
- Upgraded dependency on the edge-common version to 2.4.5.
- Added support for TLS in HTTP endpoints and Feign HTTP Clients